### PR TITLE
fix the bug when those are some data in wire

### DIFF
--- a/examples/ConvertAndRead/ConvertAndRead.ino
+++ b/examples/ConvertAndRead/ConvertAndRead.ino
@@ -19,7 +19,7 @@ void setup(void)
   digitalWrite(9, HIGH);
   
   // Reset devices
-  MCP342x::generalCallReset();
+  adc.generalCallReset();
   delay(1); // MC342x needs 300us to settle, wait 1ms
   
   // Check device present

--- a/examples/ConvertAndReadNoDelay/ConvertAndReadNoDelay.ino
+++ b/examples/ConvertAndReadNoDelay/ConvertAndReadNoDelay.ino
@@ -46,7 +46,7 @@ void setup(void)
   pinMode(led, OUTPUT);
     
   // Reset devices
-  MCP342x::generalCallReset();
+  adc.generalCallReset();
   delay(1); // MC342x needs 300us to settle
   
   // Check device present

--- a/examples/GeneralCallConversion/GeneralCallConversion.ino
+++ b/examples/GeneralCallConversion/GeneralCallConversion.ino
@@ -46,7 +46,7 @@ void setup(void)
   pinMode(led, OUTPUT);
     
   // Reset devices
-  MCP342x::generalCallReset();
+  adc.generalCallReset();
   delay(1); // MC342x needs 300us to settle
   
   // Check device present
@@ -74,7 +74,7 @@ void loop(void)
 
   if (startConversion) {
     Serial.println("General call conversion");
-    MCP342x::generalCallConversion();
+    adc.generalCallConversion();
     startConversion = false;
   }
   

--- a/src/MCP342x.cpp
+++ b/src/MCP342x.cpp
@@ -114,6 +114,21 @@ MCP342x::error_t MCP342x::read(long &result, Config& status) const
   // most appropriate configuration value (ready may have changed).
   const uint8_t len = 4;
   uint8_t buffer[len] = {};
+
+  // To fix a bug to prevent there are some data haven't been read out.
+#if 0
+  // Solution1: to flush eveny data inside of RxBufferN
+  // Remaind: need to repair wire->flush() function
+  //          Add 'rxBuffer.clear();' into it
+  // Try to flush the rxBuffer, in case of error number
+  wire->flush();
+#else
+  // Solution2: Just to read out every useless data before get useful one
+  if(wire->available() > 0 ){
+    wire->read();
+  }
+#endif
+
   wire->requestFrom(address, len);
   if (wire->available() != len)
     return errorReadFailed;

--- a/src/MCP342x.h
+++ b/src/MCP342x.h
@@ -4,7 +4,7 @@
 #include "Wire.h"
 typedef TwoWire* WireType;
 
-#define MCP342X_VERSION "1.0.4"
+#define MCP342X_VERSION "1.0.5"
 
 class MCP342x {
 public:
@@ -84,10 +84,9 @@ public:
    * one of gain1, gain2, gain4 or gain8.
    * @return Value indicating error (if any).
    */
-  error_t convert(Channel channel, Mode mode, Resolution resolution, Gain gain);  error_t convert(const Config &config) const;
-  
+  error_t convert(Channel channel, Mode mode, Resolution resolution, Gain gain);
+  error_t convert(const Config &config) const;
 
-  
   /** Read the sample value from the MCP342x device.
    * @param result The signed result.
    * @param config The contents of the configuration register.
@@ -188,6 +187,7 @@ private:
 
 class MCP342x::Config {
   friend class MCP342x;
+
 public:
   inline Config(void) : val(0) {
   };


### PR DESCRIPTION
1. when I use rp2040 to request data from MCP3425, I find it can not read anything and I debug the code and find because of those code:
```  
wire->requestFrom(address, len);
  if (wire->available() != len)
    return errorReadFailed;
```
Because those many be some data inside it before read them out. (The data if generated when I try to test if there are any data inside of it). I can clear data out of just flush the old data before read new data. So I fix it.

2. there are those functions have been changed from static funtion to normal one:
```c
  uint8_t generalCallReset(void);
  uint8_t generalCallLatch(void);
  uint8_t generalCallConversion(void);
```
But those examples to use them haven't been changed, I try to fix them.

3. the version you expect is "1.0.5", but it is "1.0.4" now. So I modify it.